### PR TITLE
allow hit statistics OR accuracy on API, prefer hit statistics internally

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -13,7 +13,9 @@ pub struct CalculateRequest {
     pub mode: i32,
     pub mods: i32,
     pub max_combo: i32,
-    pub accuracy: f32,
+    pub count_300: i32,
+    pub count_100: i32,
+    pub count_50: i32,
     pub miss_count: i32,
 }
 
@@ -66,7 +68,9 @@ async fn calculate_special_pp(
         .mods(request.mods as u32)
         .combo(request.max_combo as usize)
         .misses(request.miss_count as usize)
-        .accuracy(request.accuracy)
+        .n300(request.count_300 as usize)
+        .n100(request.count_100 as usize)
+        .n50(request.count_50 as usize)
         .calculate();
 
     let mut pp = round(result.pp as f32, 2);
@@ -124,7 +128,9 @@ async fn calculate_rosu_pp(
         })
         .mods(request.mods as u32)
         .combo(request.max_combo as usize)
-        .accuracy(request.accuracy as f64)
+        .n300(request.count_300 as usize)
+        .n100(request.count_100 as usize)
+        .n50(request.count_50 as usize)
         .n_misses(request.miss_count as usize)
         .calculate();
 
@@ -152,7 +158,9 @@ async fn recalculate_score(
         mode: score.play_mode,
         mods: score.mods,
         max_combo: score.max_combo,
-        accuracy: score.accuracy,
+        count_300: score.count_300,
+        count_100: score.count_100,
+        count_50: score.count_50,
         miss_count: score.count_misses,
     };
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -58,7 +58,9 @@ async fn calculate_conceptual_pp(
         })
         .mods(score.mods as u32)
         .combo(score.max_combo as usize)
-        .accuracy(score.accuracy as f64)
+        .n300(score.count_300 as usize)
+        .n100(score.count_100 as usize)
+        .n50(score.count_50 as usize)
         .n_misses(score.count_misses as usize)
         .calculate();
 
@@ -90,7 +92,9 @@ async fn calculate_skill_rebalance_pp(
         })
         .mods(score.mods as u32)
         .combo(score.max_combo as usize)
-        .accuracy(score.accuracy as f64)
+        .n300(score.count_300 as usize)
+        .n100(score.count_100 as usize)
+        .n50(score.count_50 as usize)
         .n_misses(score.count_misses as usize)
         .calculate();
 
@@ -114,8 +118,10 @@ async fn calculate_cursordance_pp(
     let result = cursordance::osu_2019::OsuPP::new(&beatmap)
         .mods(score.mods as u32)
         .combo(score.max_combo as usize)
+        .n300(score.count_300 as usize)
+        .n100(score.count_100 as usize)
+        .n50(score.count_50 as usize)
         .misses(score.count_misses as usize)
-        .accuracy(score.accuracy)
         .calculate();
 
     let mut pp = round(result.pp as f32, 2);
@@ -138,8 +144,10 @@ async fn calculate_no_accuracy_pp(
     let result = no_accuracy::osu_2019::OsuPP::new(&beatmap)
         .mods(score.mods as u32)
         .combo(score.max_combo as usize)
+        .n300(score.count_300 as usize)
+        .n100(score.count_100 as usize)
+        .n50(score.count_50 as usize)
         .misses(score.count_misses as usize)
-        .accuracy(score.accuracy)
         .calculate();
 
     let mut pp = round(result.pp as f32, 2);
@@ -162,8 +170,10 @@ async fn calculate_simplfy_relax_pp(
     let result = simplify_relax::osu_2019::OsuPP::new(&beatmap)
         .mods(score.mods as u32)
         .combo(score.max_combo as usize)
+        .n300(score.count_300 as usize)
+        .n100(score.count_100 as usize)
+        .n50(score.count_50 as usize)
         .misses(score.count_misses as usize)
-        .accuracy(score.accuracy)
         .calculate();
 
     let mut pp = round(result.pp as f32, 2);
@@ -186,8 +196,10 @@ async fn calculate_improved_miss_penalty_pp(
     let result = improved_miss_penalty::osu_2019::OsuPP::new(&beatmap)
         .mods(score.mods as u32)
         .combo(score.max_combo as usize)
+        .n300(score.count_300 as usize)
+        .n100(score.count_100 as usize)
+        .n50(score.count_50 as usize)
         .misses(score.count_misses as usize)
-        .accuracy(score.accuracy)
         .calculate();
 
     let mut pp = round(result.pp as f32, 2);
@@ -210,8 +222,10 @@ async fn calculate_accuracy_fun_pp(
     let result = accuracy_fun::osu_2019::OsuPP::new(&beatmap)
         .mods(score.mods as u32)
         .combo(score.max_combo as usize)
+        .n300(score.count_300 as usize)
+        .n100(score.count_100 as usize)
+        .n50(score.count_50 as usize)
         .misses(score.count_misses as usize)
-        .accuracy(score.accuracy)
         .calculate();
 
     let mut pp = round(result.pp as f32, 2);


### PR DESCRIPTION
don't know of any cases where the estimation of hit statistics using accuracy has been an issue, but this randomly popped into my head and we *should* be using hit statistics where possible. will follow with a score-service PR to use hit statistics for scores

not a breaking change, the API will allow for accuracy OR hit statistics - we still want stuff like /np using accuracy to work