### PR TITLE
Rewrite deploy part 2

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -6,7 +6,6 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use redis::AsyncCommands;
 use std::io::Write;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::{collections::HashMap, ops::DerefMut, sync::Arc, time::SystemTime};
 use tokio::sync::{Mutex, Semaphore};
 


### PR DESCRIPTION
Hopefully decreasing memory usage by not fetching all scores at once. Also removes caching the entire beatmap object as I don't think this was proven particularly useful - I wanted to cache the difficulty attributes however these aren't enough by themselves (with the current architecture, I'm going to make this possible in the future hopefully) as it still requires the beatmap.