### PR TITLE
Bump akatsuki-pp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 [[package]]
 name = "akatsuki-pp"
 version = "1.1.1"
-source = "git+https://github.com/osuAkatsuki/akatsuki-pp-rs?rev=a9b4aa4da033e1d72b96e35fd8898e32a23d2002#a9b4aa4da033e1d72b96e35fd8898e32a23d2002"
+source = "git+https://github.com/osuAkatsuki/akatsuki-pp-rs?rev=ca7e57d10faab560448a0c6b70c337965675757c#ca7e57d10faab560448a0c6b70c337965675757c"
 dependencies = [
  "rosu-map",
  "rosu-mods",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ bcrypt = "0.13.0"
 uuid = { version = "1.2.1", features = ["v4"] }
 futures = "0.3.17"
 strsim = "0.10.0"
-akatsuki-pp-rs = { package = "akatsuki-pp", git = "https://github.com/osuAkatsuki/akatsuki-pp-rs", rev = "a9b4aa4da033e1d72b96e35fd8898e32a23d2002" }
+akatsuki-pp-rs = { package = "akatsuki-pp", git = "https://github.com/osuAkatsuki/akatsuki-pp-rs", rev = "ca7e57d10faab560448a0c6b70c337965675757c" }
 reqwest = "0.11"
 async-trait = "0.1.62"
 structured-logger = "1.0.3"

--- a/src/api/routes/calculate.rs
+++ b/src/api/routes/calculate.rs
@@ -48,7 +48,7 @@ async fn calculate_relax_pp(
         usecases::beatmaps::fetch_beatmap_osu_file(request.beatmap_id, context).await?;
     let beatmap = Beatmap::from_bytes(&beatmap_bytes)?;
 
-    let mut calculate = akatsuki_pp_rs::osu_2019::OsuPP::new(&beatmap)
+    let mut calculate = akatsuki_pp_rs::osu_2019::OsuPP::from_map(&beatmap)
         .mods(request.mods as u32)
         .combo(request.max_combo as u32);
 

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -44,7 +44,7 @@ async fn calculate_special_pp(
         usecases::beatmaps::fetch_beatmap_osu_file(request.beatmap_id, context.clone()).await?;
     let beatmap = Beatmap::from_bytes(&beatmap_bytes)?;
 
-    let result = akatsuki_pp_rs::osu_2019::OsuPP::new(&beatmap)
+    let result = akatsuki_pp_rs::osu_2019::OsuPP::from_map(&beatmap)
         .mods(request.mods as u32)
         .combo(request.max_combo as u32)
         .misses(request.miss_count as u32)


### PR DESCRIPTION
Slight update to akatsuki-pp which now allows for relax calculations to be done with difficulty attributes standalone. Toying with attribute calculation to try and make deploys more time-efficient by making them beatmap based.