### PR TITLE
Try to reduce API ratelimits

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -238,7 +238,7 @@ async fn recalculate_mode_scores(
     };
 
     let beatmap_md5s: Vec<(String,)> = sqlx::query_as(&format!(
-        "SELECT DISTINCT beatmap_md5 FROM {} WHERE completed IN (2, 3) AND play_mode = ? {}",
+        "SELECT beatmap_md5, COUNT(*) AS c FROM {} WHERE completed IN (2, 3) AND play_mode = ? {} GROUP BY beatmap_md5 ORDER BY c DESC",
         scores_table, mods_query_str,
     ))
     .bind(mode)

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -272,7 +272,7 @@ async fn recalculate_mode_scores(
 
             drop(permit);
 
-            if beatmaps_processed % 1000 == 0 {
+            if beatmaps_processed % 100 == 0 {
                 log::info!(
                     beatmaps_left = total_beatmaps - beatmaps_processed as usize,
                     mode = mode,

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -29,6 +29,7 @@ fn round(x: f32, decimals: u32) -> f32 {
     (x * y).round() / y
 }
 
+const MAX_CONCURRENT_BEATMAP_TASKS: usize = 10;
 const MAX_CONCURRENT_TASKS: usize = 100;
 const BATCH_SIZE: u32 = 1000;
 
@@ -244,7 +245,7 @@ async fn recalculate_mode_scores(
     .fetch_all(ctx.database.get().await?.deref_mut())
     .await?;
 
-    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_TASKS));
+    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_BEATMAP_TASKS));
 
     let mut futures = FuturesUnordered::new();
 

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -382,7 +382,7 @@ async fn recalculate_statuses(
 
     let beatmap_md5s: Vec<(String,)> = sqlx::query_as(
         &format!(
-            "SELECT DISTINCT (beatmap_md5) FROM {} WHERE userid = ? AND completed IN (2, 3) AND play_mode = ?",
+            "SELECT DISTINCT beatmap_md5 FROM {} WHERE userid = ? AND completed IN (2, 3) AND play_mode = ?",
             scores_table
         )
     )


### PR DESCRIPTION
Changed the query which fetches beatmap md5s to return in order of score count - the idea is the more plays we have on the beatmap, the less likely it is to have to make an API call in beatmaps-service. Also reduced the concurrent count to avoid rate limits once we hit the beatmaps that we need to do API calls for.