### PR TITLE
Fix Rust 2024 never type fallback compatibility

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -603,7 +603,7 @@ async fn recalculate_user(
         };
 
         redis_connection
-            .zadd(
+            .zadd::<_, _, _, ()>(
                 format!("ripple:{}:{}", redis_leaderboard, stats_prefix),
                 user_id.to_string(),
                 new_pp,
@@ -611,7 +611,7 @@ async fn recalculate_user(
             .await?;
 
         redis_connection
-            .zadd(
+            .zadd::<_, _, _, ()>(
                 format!(
                     "ripple:{}:{}:{}",
                     redis_leaderboard,
@@ -625,7 +625,7 @@ async fn recalculate_user(
     }
 
     redis_connection
-        .publish("peppy:update_cached_stats", user_id)
+        .publish::<_, _, ()>("peppy:update_cached_stats", user_id)
         .await?;
 
     Ok(())


### PR DESCRIPTION
## Summary
Add explicit type annotations to Redis `zadd` and `publish` calls to satisfy Rust 2024 type inference requirements.

This fixes the CI build failure:
```
error: this function depends on never type fallback being `()`
```

## Changes
- `.zadd(...)` → `.zadd::<_, _, _, ()>(...)`
- `.publish(...)` → `.publish::<_, _, ()>(...)`

🤖 Generated with [Claude Code](https://claude.ai/code)