### PR TITLE
Fix GLIBC version mismatch in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 
-FROM rust:latest AS build
+FROM rust:bookworm AS build
 
 RUN cargo new --lib /performance-service
 COPY Cargo.toml Cargo.lock /performance-service/


### PR DESCRIPTION
## Summary
Use `rust:bookworm` instead of `rust:latest` for the build stage to match the runtime stage (`debian:bookworm-slim`).

## Problem
`rust:latest` is now based on a newer Debian version with GLIBC 2.38, while `bookworm-slim` has GLIBC 2.36. This causes runtime failures:
```
/usr/local/bin/performance-service: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

## Fix
Pin the build image to `rust:bookworm` to ensure GLIBC compatibility with the runtime image.

(This fix existed on the `le-recalc` branch from August 2025 but was never merged to main)

🤖 Generated with [Claude Code](https://claude.ai/code)